### PR TITLE
Related-Bug: #1606947

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -33,6 +33,16 @@ config.fetch().then(() => {
       }}
   });
 
+    if(sessionStorage.getItem("gohan_contrail") == "true") {
+        $.ajaxSetup({
+            statusCode: {
+                307: function () {
+                    window.parent.location.reload();
+                }
+            }
+        });
+    }
+
   router.route('', 'toppage', () => {
     router.navigate('v1.0/tenant/networks');
   });

--- a/app/js/views/appView.js
+++ b/app/js/views/appView.js
@@ -236,7 +236,7 @@ export default class AppView extends View {
     });
     if(sessionStorage.getItem("gohan_contrail") == "true") {
         //No need to pass-on credentials,as session is already authenticated [Embedded in contrailUI]
-        loginView.login();
+        this.userModel.loginTenant(sessionStorage.getItem('tenant'));
         return this;
     } else {
         this.$el.html(loginView.render().el);
@@ -253,7 +253,8 @@ export default class AppView extends View {
       this.showLogin();
     } else {
       this.$el.html(this.template());
-      this.$('#header').append(this.headerView.render().el);
+      if(this.userModel.getItem("gohan_contrail") != true)
+        this.$('#header').append(this.headerView.render().el);
       this.$('#sidebar').append(this.sidebarView.render().el);
       this.$('#bread-crumb').append(this.breadCrumb.render().el);
     }


### PR DESCRIPTION
Changes related to embedding gohanUI in contrailUI
Reload the parent frame on session expiry by tracking ajax response code
"307"
Populate the tenant name in sessionStorage before loading gohanUI such
that the first 2 requests can be avoided (1 for "/tokens"
(unscopedToken) and other for "/tenants" (getting tenants)
